### PR TITLE
chore: add Prettier plugin support for Svelte files

### DIFF
--- a/apps/site/.prettierrc.mjs
+++ b/apps/site/.prettierrc.mjs
@@ -10,6 +10,12 @@ export default {
         parser: 'astro',
       },
     },
+    {
+      files: '*.svelte',
+      options: {
+        parser: 'svelte',
+      },
+    },
   ],
-  plugins: ['prettier-plugin-astro'],
+  plugins: ['prettier-plugin-astro', 'prettier-plugin-svelte'],
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clean:modules": "find $(git rev-parse --show-toplevel) -name 'node_modules' -type d -prune -exec rm -rf '{}' +",
     "dev": "turbo run dev",
     "dev:astro": "pnpm --filter @repo/site dev",
-    "format": "prettier --write \"{packages,apps}/*/src/**/*.{js,jsx,ts,tsx,scss,css,astro}\"",
+    "format": "prettier --write \"{packages,apps}/*/src/**/*.{js,jsx,ts,tsx,scss,css,astro,svelte}\"",
     "lint": "turbo run lint",
     "prepare": "husky",
     "preview:astro": "pnpm --filter @repo/site preview",
@@ -24,6 +24,8 @@
     "@types/node": "^22.14.0",
     "husky": "^9.1.7",
     "prettier": "^3.5.3",
+    "prettier-plugin-astro": "^0.14.1",
+    "prettier-plugin-svelte": "^3.4.0",
     "turbo": "^2.5.2",
     "typescript": "5.7.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
+      prettier-plugin-astro:
+        specifier: ^0.14.1
+        version: 0.14.1
+      prettier-plugin-svelte:
+        specifier: ^3.4.0
+        version: 3.4.0(prettier@3.5.3)(svelte@5.28.2)
       turbo:
         specifier: ^2.5.2
         version: 2.5.2
@@ -34,13 +40,13 @@ importers:
     dependencies:
       '@astrojs/svelte':
         specifier: ^7.0.13
-        version: 7.0.13(@types/node@22.15.18)(astro@5.7.10(@types/node@22.15.18)(rollup@4.40.1)(sass-embedded@1.83.4)(typescript@5.7.3))(sass-embedded@1.83.4)(svelte@5.28.2)(typescript@5.7.3)
+        version: 7.0.13(@types/node@22.15.18)(astro@5.7.10(@types/node@22.15.18)(rollup@4.40.1)(sass-embedded@1.83.4)(typescript@5.7.3)(yaml@1.10.2))(sass-embedded@1.83.4)(svelte@5.28.2)(typescript@5.7.3)(yaml@1.10.2)
       '@repo/ui':
         specifier: workspace:*
         version: link:../../packages/ui
       astro:
         specifier: ^5.7.10
-        version: 5.7.10(@types/node@22.15.18)(rollup@4.40.1)(sass-embedded@1.83.4)(typescript@5.7.3)
+        version: 5.7.10(@types/node@22.15.18)(rollup@4.40.1)(sass-embedded@1.83.4)(typescript@5.7.3)(yaml@1.10.2)
       svelte:
         specifier: ^5.28.2
         version: 5.28.2
@@ -50,10 +56,10 @@ importers:
         version: link:../../packages/vitest-config
       '@vitest/coverage-istanbul':
         specifier: ^3.0.7
-        version: 3.0.7(vitest@3.0.7(@types/debug@4.1.12)(@types/node@22.15.18)(@vitest/ui@3.0.7)(jsdom@26.0.0)(sass-embedded@1.83.4))
+        version: 3.0.7(vitest@3.0.7(@types/debug@4.1.12)(@types/node@22.15.18)(@vitest/ui@3.0.7)(jsdom@26.0.0)(sass-embedded@1.83.4)(yaml@1.10.2))
       astro-purgecss:
         specifier: ^5.2.2
-        version: 5.2.2(astro@5.7.10(@types/node@22.15.18)(rollup@4.40.1)(sass-embedded@1.83.4)(typescript@5.7.3))(purgecss@7.0.2)
+        version: 5.2.2(astro@5.7.10(@types/node@22.15.18)(rollup@4.40.1)(sass-embedded@1.83.4)(typescript@5.7.3)(yaml@1.10.2))(purgecss@7.0.2)
       prettier-plugin-astro:
         specifier: ^0.14.1
         version: 0.14.1
@@ -65,7 +71,7 @@ importers:
         version: 1.6.6
       vitest:
         specifier: ^3.0.7
-        version: 3.0.7(@types/debug@4.1.12)(@types/node@22.15.18)(@vitest/ui@3.0.7)(jsdom@26.0.0)(sass-embedded@1.83.4)
+        version: 3.0.7(@types/debug@4.1.12)(@types/node@22.15.18)(@vitest/ui@3.0.7)(jsdom@26.0.0)(sass-embedded@1.83.4)(yaml@1.10.2)
 
   packages/eslint-config:
     devDependencies:
@@ -104,13 +110,13 @@ importers:
         version: 8.24.0(eslint@9.21.0)(typescript@5.7.3)
       vitest:
         specifier: ^3.0.7
-        version: 3.0.7(@types/debug@4.1.12)(@types/node@22.15.18)(@vitest/ui@3.0.7)(jsdom@26.0.0)(sass-embedded@1.83.4)
+        version: 3.0.7(@types/debug@4.1.12)(@types/node@22.15.18)(@vitest/ui@3.0.7)(jsdom@26.0.0)(sass-embedded@1.83.4)(yaml@1.10.2)
 
   packages/typescript-config:
     devDependencies:
       vitest:
         specifier: ^3.0.7
-        version: 3.0.7(@types/debug@4.1.12)(@types/node@22.15.18)(@vitest/ui@3.0.7)(jsdom@26.0.0)(sass-embedded@1.83.4)
+        version: 3.0.7(@types/debug@4.1.12)(@types/node@22.15.18)(@vitest/ui@3.0.7)(jsdom@26.0.0)(sass-embedded@1.83.4)(yaml@1.10.2)
 
   packages/ui:
     dependencies:
@@ -162,7 +168,7 @@ importers:
         version: link:../typescript-config
       '@vitest/coverage-istanbul':
         specifier: ^3.0.7
-        version: 3.0.7(vitest@3.0.7(@types/debug@4.1.12)(@types/node@22.15.18)(@vitest/ui@3.0.7)(jsdom@26.0.0)(sass-embedded@1.83.4))
+        version: 3.0.7(vitest@3.0.7(@types/debug@4.1.12)(@types/node@22.15.18)(@vitest/ui@3.0.7)(jsdom@26.0.0)(sass-embedded@1.83.4)(yaml@1.10.2))
       '@vitest/ui':
         specifier: 3.0.7
         version: 3.0.7(vitest@3.0.7)
@@ -177,7 +183,7 @@ importers:
         version: 17.1.0
       vitest:
         specifier: ^3.0.7
-        version: 3.0.7(@types/debug@4.1.12)(@types/node@22.15.18)(@vitest/ui@3.0.7)(jsdom@26.0.0)(sass-embedded@1.83.4)
+        version: 3.0.7(@types/debug@4.1.12)(@types/node@22.15.18)(@vitest/ui@3.0.7)(jsdom@26.0.0)(sass-embedded@1.83.4)(yaml@1.10.2)
 
 packages:
 
@@ -3549,6 +3555,12 @@ packages:
     resolution: {integrity: sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==}
     engines: {node: ^14.15.0 || >=16.0.0}
 
+  prettier-plugin-svelte@3.4.0:
+    resolution: {integrity: sha512-pn1ra/0mPObzqoIQn/vUTR3ZZI6UuZ0sHqMK5x2jMLGrs53h0sXhkVuDcrlssHwIMk7FYrMjHBPoUSyyEEDlBQ==}
+    peerDependencies:
+      prettier: ^3.0.0
+      svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
+
   prettier@3.5.3:
     resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
     engines: {node: '>=14'}
@@ -5033,14 +5045,14 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/svelte@7.0.13(@types/node@22.15.18)(astro@5.7.10(@types/node@22.15.18)(rollup@4.40.1)(sass-embedded@1.83.4)(typescript@5.7.3))(sass-embedded@1.83.4)(svelte@5.28.2)(typescript@5.7.3)':
+  '@astrojs/svelte@7.0.13(@types/node@22.15.18)(astro@5.7.10(@types/node@22.15.18)(rollup@4.40.1)(sass-embedded@1.83.4)(typescript@5.7.3)(yaml@1.10.2))(sass-embedded@1.83.4)(svelte@5.28.2)(typescript@5.7.3)(yaml@1.10.2)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4))
-      astro: 5.7.10(@types/node@22.15.18)(rollup@4.40.1)(sass-embedded@1.83.4)(typescript@5.7.3)
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4)(yaml@1.10.2))
+      astro: 5.7.10(@types/node@22.15.18)(rollup@4.40.1)(sass-embedded@1.83.4)(typescript@5.7.3)(yaml@1.10.2)
       svelte: 5.28.2
       svelte2tsx: 0.7.37(svelte@5.28.2)(typescript@5.7.3)
       typescript: 5.7.3
-      vite: 6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4)
+      vite: 6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4)(yaml@1.10.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -5655,25 +5667,25 @@ snapshots:
     dependencies:
       acorn: 8.14.1
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4)))(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4)(yaml@1.10.2)))(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4)(yaml@1.10.2))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4)(yaml@1.10.2))
       debug: 4.4.0
       svelte: 5.28.2
-      vite: 6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4)
+      vite: 6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4)(yaml@1.10.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4))':
+  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4)(yaml@1.10.2))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4)))(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4)(yaml@1.10.2)))(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4)(yaml@1.10.2))
       debug: 4.4.0
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
       svelte: 5.28.2
-      vite: 6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4)
-      vitefu: 1.0.6(vite@6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4))
+      vite: 6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4)(yaml@1.10.2)
+      vitefu: 1.0.6(vite@6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4)(yaml@1.10.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -5890,7 +5902,7 @@ snapshots:
     dependencies:
       receptor: 1.0.0
 
-  '@vitest/coverage-istanbul@3.0.7(vitest@3.0.7(@types/debug@4.1.12)(@types/node@22.15.18)(@vitest/ui@3.0.7)(jsdom@26.0.0)(sass-embedded@1.83.4))':
+  '@vitest/coverage-istanbul@3.0.7(vitest@3.0.7(@types/debug@4.1.12)(@types/node@22.15.18)(@vitest/ui@3.0.7)(jsdom@26.0.0)(sass-embedded@1.83.4)(yaml@1.10.2))':
     dependencies:
       '@istanbuljs/schema': 0.1.3
       debug: 4.4.0
@@ -5902,7 +5914,7 @@ snapshots:
       magicast: 0.3.5
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.7(@types/debug@4.1.12)(@types/node@22.15.18)(@vitest/ui@3.0.7)(jsdom@26.0.0)(sass-embedded@1.83.4)
+      vitest: 3.0.7(@types/debug@4.1.12)(@types/node@22.15.18)(@vitest/ui@3.0.7)(jsdom@26.0.0)(sass-embedded@1.83.4)(yaml@1.10.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -5913,13 +5925,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.7(vite@6.2.0(@types/node@22.15.18)(sass-embedded@1.83.4))':
+  '@vitest/mocker@3.0.7(vite@6.2.0(@types/node@22.15.18)(sass-embedded@1.83.4)(yaml@1.10.2))':
     dependencies:
       '@vitest/spy': 3.0.7
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.0(@types/node@22.15.18)(sass-embedded@1.83.4)
+      vite: 6.2.0(@types/node@22.15.18)(sass-embedded@1.83.4)(yaml@1.10.2)
 
   '@vitest/pretty-format@3.0.7':
     dependencies:
@@ -5949,7 +5961,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.12
       tinyrainbow: 2.0.0
-      vitest: 3.0.7(@types/debug@4.1.12)(@types/node@22.15.18)(@vitest/ui@3.0.7)(jsdom@26.0.0)(sass-embedded@1.83.4)
+      vitest: 3.0.7(@types/debug@4.1.12)(@types/node@22.15.18)(@vitest/ui@3.0.7)(jsdom@26.0.0)(sass-embedded@1.83.4)(yaml@1.10.2)
 
   '@vitest/utils@3.0.7':
     dependencies:
@@ -6111,12 +6123,12 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  astro-purgecss@5.2.2(astro@5.7.10(@types/node@22.15.18)(rollup@4.40.1)(sass-embedded@1.83.4)(typescript@5.7.3))(purgecss@7.0.2):
+  astro-purgecss@5.2.2(astro@5.7.10(@types/node@22.15.18)(rollup@4.40.1)(sass-embedded@1.83.4)(typescript@5.7.3)(yaml@1.10.2))(purgecss@7.0.2):
     dependencies:
-      astro: 5.7.10(@types/node@22.15.18)(rollup@4.40.1)(sass-embedded@1.83.4)(typescript@5.7.3)
+      astro: 5.7.10(@types/node@22.15.18)(rollup@4.40.1)(sass-embedded@1.83.4)(typescript@5.7.3)(yaml@1.10.2)
       purgecss: 7.0.2
 
-  astro@5.7.10(@types/node@22.15.18)(rollup@4.40.1)(sass-embedded@1.83.4)(typescript@5.7.3):
+  astro@5.7.10(@types/node@22.15.18)(rollup@4.40.1)(sass-embedded@1.83.4)(typescript@5.7.3)(yaml@1.10.2):
     dependencies:
       '@astrojs/compiler': 2.12.0
       '@astrojs/internal-helpers': 0.6.1
@@ -6169,8 +6181,8 @@ snapshots:
       unist-util-visit: 5.0.0
       unstorage: 1.16.0
       vfile: 6.0.3
-      vite: 6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4)
-      vitefu: 1.0.6(vite@6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4))
+      vite: 6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4)(yaml@1.10.2)
+      vitefu: 1.0.6(vite@6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4)(yaml@1.10.2))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.2
@@ -8999,6 +9011,11 @@ snapshots:
       prettier: 3.5.3
       sass-formatter: 0.7.9
 
+  prettier-plugin-svelte@3.4.0(prettier@3.5.3)(svelte@5.28.2):
+    dependencies:
+      prettier: 3.5.3
+      svelte: 5.28.2
+
   prettier@3.5.3: {}
 
   prismjs@1.30.0: {}
@@ -10259,13 +10276,13 @@ snapshots:
       replace-ext: 2.0.0
       teex: 1.0.1
 
-  vite-node@3.0.7(@types/node@22.15.18)(sass-embedded@1.83.4):
+  vite-node@3.0.7(@types/node@22.15.18)(sass-embedded@1.83.4)(yaml@1.10.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.2.0(@types/node@22.15.18)(sass-embedded@1.83.4)
+      vite: 6.2.0(@types/node@22.15.18)(sass-embedded@1.83.4)(yaml@1.10.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -10280,7 +10297,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.2.0(@types/node@22.15.18)(sass-embedded@1.83.4):
+  vite@6.2.0(@types/node@22.15.18)(sass-embedded@1.83.4)(yaml@1.10.2):
     dependencies:
       esbuild: 0.25.0
       postcss: 8.5.3
@@ -10289,8 +10306,9 @@ snapshots:
       '@types/node': 22.15.18
       fsevents: 2.3.3
       sass-embedded: 1.83.4
+      yaml: 1.10.2
 
-  vite@6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4):
+  vite@6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4)(yaml@1.10.2):
     dependencies:
       esbuild: 0.25.0
       fdir: 6.4.4(picomatch@4.0.2)
@@ -10302,15 +10320,16 @@ snapshots:
       '@types/node': 22.15.18
       fsevents: 2.3.3
       sass-embedded: 1.83.4
+      yaml: 1.10.2
 
-  vitefu@1.0.6(vite@6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4)):
+  vitefu@1.0.6(vite@6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4)(yaml@1.10.2)):
     optionalDependencies:
-      vite: 6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4)
+      vite: 6.3.5(@types/node@22.15.18)(sass-embedded@1.83.4)(yaml@1.10.2)
 
-  vitest@3.0.7(@types/debug@4.1.12)(@types/node@22.15.18)(@vitest/ui@3.0.7)(jsdom@26.0.0)(sass-embedded@1.83.4):
+  vitest@3.0.7(@types/debug@4.1.12)(@types/node@22.15.18)(@vitest/ui@3.0.7)(jsdom@26.0.0)(sass-embedded@1.83.4)(yaml@1.10.2):
     dependencies:
       '@vitest/expect': 3.0.7
-      '@vitest/mocker': 3.0.7(vite@6.2.0(@types/node@22.15.18)(sass-embedded@1.83.4))
+      '@vitest/mocker': 3.0.7(vite@6.2.0(@types/node@22.15.18)(sass-embedded@1.83.4)(yaml@1.10.2))
       '@vitest/pretty-format': 3.0.7
       '@vitest/runner': 3.0.7
       '@vitest/snapshot': 3.0.7
@@ -10326,8 +10345,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.0(@types/node@22.15.18)(sass-embedded@1.83.4)
-      vite-node: 3.0.7(@types/node@22.15.18)(sass-embedded@1.83.4)
+      vite: 6.2.0(@types/node@22.15.18)(sass-embedded@1.83.4)(yaml@1.10.2)
+      vite-node: 3.0.7(@types/node@22.15.18)(sass-embedded@1.83.4)(yaml@1.10.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12


### PR DESCRIPTION
Added Prettier plugin support for Svelte files by updating the Prettier configuration and plugins. This ensures consistent formatting for .svelte files across the project.